### PR TITLE
Stop codon option is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Datasets for training and testing are stored in the `data` folder. Please specif
 
 ### User-Specified Data:
 
-AMPlify only accepts 20 standard amino acids. However, if the user would like to specify the stop codon with adding a asterisk character to the end of the peptide sequences, AMPlify would ignore the last character and allow that peptide to be participate in the training or inference stages.
+AMPlify only accepts 20 standard amino acids. However, if the user specifies the stop codon with adding a asterisk character to the end of the peptide sequences, AMPlify would ignore the last character of the peptides and allow them to be participate in the training or inference stages.
 
 ### Pre-trained sub-models
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Datasets for training and testing are stored in the `data` folder. Please specif
 * Imbalanced training set: `AMPlify_AMP_train_common.fa` + `AMPlify_non_AMP_train_imbalanced.fa`
 * Imbalanced test set: `AMPlify_AMP_test_common.fa` + `AMPlify_non_AMP_test_imbalanced.fa`
 
+### User-Specified Data:
+
+AMPlify only accepts 20 standard amino acids. However, if the user would like to specify the stop codon with adding a asterisk character to the end of the peptide sequences, AMPlify would ignore the last character and allow that peptide to be participate in the training or inference stages.
 
 ### Pre-trained sub-models
 

--- a/src/AMPlify.py
+++ b/src/AMPlify.py
@@ -199,11 +199,12 @@ def main():
     # look for indices of valid sequences
     valid_ix = []
     for i in range(len(peptide)):
-        if len(peptide[i]) <= 200 and len(peptide[i]) >= 2 and set(peptide[i])-set(aa) == set():
-            valid_ix.append(i)
+        if len(peptide[i]) <= 200 and len(peptide[i]) >= 2:
+            if set(peptide[i])-set(aa) == set() or (set(peptide[i][:-1])-set(aa)==set() and peptide[i][-1]=='*'): # either does not contain nonstandard amino acids or the last character is '*'
+                valid_ix.append(i)
             
     # select valid sequences for prediction
-    peptide_valid = [peptide[i] for i in valid_ix]
+    peptide_valid = [peptide[i] if peptide[i][-1]!="*" else peptide[i][:-1] for i in valid_ix]
     
     # generate one-hot encoding input and pad sequences into MAX_LEN long
     X_seq_valid = one_hot_padding(peptide_valid, MAX_LEN)

--- a/src/train_amplify.py
+++ b/src/train_amplify.py
@@ -107,10 +107,16 @@ def main():
     non_AMP_train = []
     for seq_record in SeqIO.parse(args.amp_tr, 'fasta'):
         # "../data/AMPlify_AMP_train_common.fa"
-        AMP_train.append(str(seq_record.seq))
+        if str(seq_record.seq)[-1] == '*':
+            AMP_train.append(str(seq_record.seq)[:-1])
+        else:
+            AMP_train.append(str(seq_record.seq))
     for seq_record in SeqIO.parse(args.non_amp_tr, 'fasta'):
         # "../data/AMPlify_non_AMP_train_balanced.fa"
-        non_AMP_train.append(str(seq_record.seq))
+        if str(seq_record.seq)[-1] == '*':
+            non_AMP_train.append(str(seq_record.seq)[:-1])
+        else:
+            non_AMP_train.append(str(seq_record.seq))
         
     # sequences for training sets
     train_seq = AMP_train + non_AMP_train    
@@ -136,10 +142,16 @@ def main():
         non_AMP_test = []      
         for seq_record in SeqIO.parse(args.amp_te, 'fasta'):
             # "../data/AMPlify_AMP_test_common.fa"
-            AMP_test.append(str(seq_record.seq))
+            if str(seq_record.seq)[-1] == '*':
+                AMP_test.append(str(seq_record.seq)[:-1])
+            else:
+                AMP_test.append(str(seq_record.seq))
         for seq_record in SeqIO.parse(args.non_amp_te, 'fasta'):
             # "../data/AMPlify_non_AMP_test_balanced.fa"
-            non_AMP_test.append(str(seq_record.seq))
+            if str(seq_record.seq)[-1] == '*':
+                non_AMP_test.append(str(seq_record.seq)[:-1])
+            else:
+                non_AMP_test.append(str(seq_record.seq))
         
         # sequences for test sets
         test_seq = AMP_test + non_AMP_test


### PR DESCRIPTION
Hello,

Here, I added the option to specify stop codons with asterisks (*) for training and inference scripts of AMPlify. Users are still expected to use standard amino acids but as an exception, they can specify the peptides are not truncated from the end by adding "*" to their peptides as the last character. AMPlify's prediction output for inference would still show these asterisks for referencing's sake. However, in any of the stages (neither training nor test), we do not include "*" character in AMPlify's steps. It basically ignores the last character if it is "*". 
